### PR TITLE
use specific composer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk --no-cache add \
   php7-curl \
   git \
   curl
-RUN mkdir /app && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN mkdir /app && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --version=1.10.19 --filename=composer
 WORKDIR /app
 COPY . /app/
 


### PR DESCRIPTION
More recent versions will currently break the build because they don't like the capitalization of some metadata in extension composer.json files