### PR TITLE
insert the gcwiki header with js

### DIFF
--- a/extensions/SkinTweaksGCwiki/SkinTweaksGCwikiHooks.php
+++ b/extensions/SkinTweaksGCwiki/SkinTweaksGCwikiHooks.php
@@ -30,27 +30,13 @@ class SkinTweaksGCwikiHooks {
             'active' => ''
         ];
 		$bar['gctools'] = [$accLink, $gccLink, $messLink];
-		return true;
+		return;
 	}
 
 
     public static function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
-        $out->addModuleStyles( [ 'ext.skintweaksgcwiki.styles' ] );
-        return true;
-    }
-
-
-    public static function onAfterFinalPageOutput( $output ) {
-        $fipHeader = '<div class="collab-fip-header" style="height:35px; clear:both; background-color:white;">
-		<object type="image/svg+xml" tabindex="-1" role="img" data="extensions/SkinTweaksGCwiki/resources/images/sig-alt-en.svg" aria-label="Symbol of the Government of Canada" style="height:25px; float:left; padding:5px 10px;"></object>
-	</div>
-        <div id="app-brand-name"><span style="font-weight:600">GC</span>wiki</div>';
-	
-        $out = ob_get_clean();
-        // change final html in $out
-        ob_start();
-        echo $fipHeader . $out;
-        return true;
+        $out->addModules( [ 'ext.skintweaksgcwiki' ] );
+        return;
     }
 
 }

--- a/extensions/SkinTweaksGCwiki/extension.json
+++ b/extensions/SkinTweaksGCwiki/extension.json
@@ -14,8 +14,9 @@
 		]
 	},
 	"ResourceModules": {
-		"ext.skintweaksgcwiki.styles": {
-			"styles": "css/skintweaksgcwiki.css"
+		"ext.skintweaksgcwiki": {
+			"styles": "css/skintweaksgcwiki.css",
+			"scripts": "js/skintweaksgcwiki.js"
 		}
 	},
 	"ResourceFileModulePaths": {
@@ -27,8 +28,7 @@
 	},
 	"Hooks": {
 		"SkinBuildSidebar": "SkinTweaksGCwikiHooks::onSkinBuildSidebar",
-		"BeforePageDisplay": "SkinTweaksGCwikiHooks::onBeforePageDisplay",
-		"AfterFinalPageOutput": "SkinTweaksGCwikiHooks::onAfterFinalPageOutput"
+		"BeforePageDisplay": "SkinTweaksGCwikiHooks::onBeforePageDisplay"
 	},
 	"manifest_version": 2
 }

--- a/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki.css
+++ b/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki.css
@@ -13,6 +13,11 @@ div#mw-head {
     top:90px;
 }
 
+#collab-fip-header{
+    height:35px;
+    clear:both;
+    background-color:white;
+}
 #app-brand-name{
     background:#6D4E86; 
     position:absolute; 

--- a/extensions/SkinTweaksGCwiki/resources/js/skintweaksgcwiki.js
+++ b/extensions/SkinTweaksGCwiki/resources/js/skintweaksgcwiki.js
@@ -1,0 +1,12 @@
+function addTopBar(){
+
+    var header = document.createElement('div');
+    header.id = "collab-fip-header";
+
+    header.innerHTML = '<object type="image/svg+xml" tabindex="-1" role="img" data="extensions/SkinTweaksGCwiki/resources/images/sig-alt-en.svg" aria-label="Symbol of the Government of Canada" style="height:25px; float:left; padding:5px 10px;"></object> \
+    <div id="app-brand-name"><span style="font-weight:600">GC</span>wiki</div>';
+
+    document.body.insertBefore(header, document.body.firstChild);
+}
+
+addTopBar();


### PR DESCRIPTION
The way it was being added before was breaking some scripts, plus this way doesn't intercept the response as it's being sent to modify it.

fixes #191 