### PR TITLE
port over any missing gcpedia config

### DIFF
--- a/config-gcpedia.php
+++ b/config-gcpedia.php
@@ -1,6 +1,10 @@
 <?php
 
-$wgArticlePath = "/$1";
+$wgScriptPath       = "/gcwiki";
+$wgArticlePath      = '/wiki/$1';
+$wgUsePathInfo = true;
+$wgUploadPath = "$wgScriptPath/images";
+$wgResourceBasePath = $wgScriptPath;
 
 wfLoadSkin( 'Vector' );
 $wgLocaltimezone = "America/Montreal";

--- a/config-gcpedia.php
+++ b/config-gcpedia.php
@@ -1,10 +1,6 @@
 <?php
 
-$wgScriptPath       = "/gcwiki";
-$wgArticlePath      = '/wiki/$1';
 $wgUsePathInfo = true;
-$wgUploadPath = "$wgScriptPath/images";
-$wgResourceBasePath = $wgScriptPath;
 
 wfLoadSkin( 'Vector' );
 $wgLocaltimezone = "America/Montreal";

--- a/config-gcpedia.php
+++ b/config-gcpedia.php
@@ -32,7 +32,7 @@ $wgGroupPermissions['user']['undelete']       = true;
 $wgGroupPermissions['user']['deletedhistory'] = true;
 
 $wgEnableUploads = true;
-$wgFileExtensions = array('pub','png','gif','jpg','jpeg','pdf','xls','docx','pptx','doc','ppt','svg','xml','mpg','odp','odt','wmv','flv','vsd','mpp','ai','zip','txt','wpd','rtf','drf','xlsx','xlsm', 'oft');
+$wgFileExtensions = array('pub','png','gif','jpg','jpeg','pdf','xls','docx','pptx','doc','ppt','svg','xml','mpg','odp','odt','wmv','flv','vsd','mpp','ai','zip','txt','wpd','rtf','drf','xlsx','xlsm', 'oft','swf', 'ppsx','dotx', 'potx');
 
 $wgUseAjax = true;
 $wgEnableAPI = true;

--- a/config-gcpedia.php
+++ b/config-gcpedia.php
@@ -22,7 +22,21 @@ $wgLogos = [
     ],
 ];
 
-$wgNamespacesWithSubpages[NS_MAIN] = true;
+# To enable displayed menu structure when creating sub-pages
+$wgNamespacesWithSubpages = array_fill(0, 100, true);
+
+$wgAllowUserCss = true;
+$wgAllowUserJs  = true;
+
+$wgExtraNamespaces[100] = "Portal";
+$wgExtraNamespaces[101] = "Portal_Talk";
+$wgNamespacesWithSubpages[100] = true;
+$wgNamespacesWithSubpages[101] = true;
+
+$wgExtraNamespaces[102] = "Community";
+$wgExtraNamespaces[103] = "Community_Talk";
+$wgNamespacesWithSubpages[102] = true;
+$wgNamespacesWithSubpages[103] = true;
   
 # Disable EDIT for 'everyone'
 $wgGroupPermissions['*']['edit']              = false;
@@ -37,7 +51,9 @@ $wgGroupPermissions['user']['deletedhistory'] = true;
 
 $wgEnableUploads = true;
 $wgFileExtensions = array('pub','png','gif','jpg','jpeg','pdf','xls','docx','pptx','doc','ppt','svg','xml','mpg','odp','odt','wmv','flv','vsd','mpp','ai','zip','txt','wpd','rtf','drf','xlsx','xlsm', 'oft','swf', 'ppsx','dotx', 'potx');
+$wgMaxUploadSize = 1024*1024*32;
 
+$wgRawHtml = true;
 $wgUseAjax = true;
 $wgEnableAPI = true;
 

--- a/docker/LocalSettings.php.docker
+++ b/docker/LocalSettings.php.docker
@@ -47,8 +47,17 @@ $wgLogos = [ '1x' => "$wgResourceBasePath/resources/assets/wiki.png" ];
 $wgEnableEmail = true;
 $wgEnableUserEmail = true; # UPO
 
-$wgEmergencyContact = "apache@wiki.local";
-$wgPasswordSender = "apache@wiki.local";
+## smtp authentication
+$wgPasswordSender = (getenv('WIKI_PASSWORDSENDER') != '') ? getenv('WIKI_PASSWORDSENDER') : '';
+if (getenv('WIKI_SMTP_HOST')){
+	$wgSMTP = array(
+	'host'     => getenv('WIKI_SMTP_HOST'), // could also be an IP address. Where the SMTP server is located
+	'port'     => getenv('WIKI_SMTP_PORT'),                 // Port to use when connecting to the SMTP server
+	'auth'     => getenv('WIKI_SMTP_AUTH'),               // Should we use SMTP authentication (true or false)
+	'username' => getenv('WIKI_SMTP_USERNAME'),     // Username to use for SMTP authentication (if being used)
+	'password' => getenv('WIKI_SMTP_PASSWORD')
+	);
+}
 
 $wgEnotifUserTalk = false; # UPO
 $wgEnotifWatchlist = false; # UPO

--- a/docker/LocalSettings.php.docker
+++ b/docker/LocalSettings.php.docker
@@ -72,12 +72,10 @@ $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 $wgSharedTables[] = "actor";
 
 ## Shared memory settings
-$wgMainCacheType = CACHE_ACCEL;
-$wgMemCachedServers = [];
+$wgMainCacheType = (getenv('CACHE_TYPE') == 'CACHE_MEMCACHED') ? CACHE_MEMCACHED : CACHE_ACCEL;
 
 ## To enable image uploads, make sure the 'images' directory
 ## is writable, then set this to true:
-$wgEnableUploads = false;
 $wgUseImageMagick = true;
 $wgImageMagickConvertCommand = "/usr/bin/convert";
 
@@ -109,10 +107,6 @@ $wgSecretKey = (getenv('SECRETKEY') != '') ? getenv('SECRETKEY') : 'Secret123';
 
 # Changing this will log out all existing sessions.
 $wgAuthenticationTokenVersion = "1";
-
-# Site upgrade key. Must be set to a string (default provided) to turn on the
-# web installer while LocalSettings.php is in place
-$wgUpgradeKey = (getenv('UPGRADEKEY') != '') ? getenv('UPGRADEKEY') : 'Secret321';
 
 ## For attaching licensing metadata to pages, and displaying an
 ## appropriate copyright notice / icon. GNU Free Documentation

--- a/docker/LocalSettings.php.docker
+++ b/docker/LocalSettings.php.docker
@@ -26,7 +26,8 @@ $wgSitename = "Dev wiki instance";
 ## For more information on customizing the URLs
 ## (like /w/index.php/Page_title to /wiki/Page_title) please see:
 ## https://www.mediawiki.org/wiki/Manual:Short_URL
-$wgScriptPath = "";
+$wgScriptPath = (getenv('SCRIPT_PATH') != '') ? getenv('SCRIPT_PATH') : "";
+$wgArticlePath = (getenv('ARTICLE_PATH') != '') ? getenv('ARTICLE_PATH') : $wgArticlePath;
 
 ## The protocol and server name to use in fully-qualified URLs
 $host = (getenv('HOST') != '') ? getenv('HOST') : 'localhost';

--- a/docker/LocalSettings.php.docker
+++ b/docker/LocalSettings.php.docker
@@ -27,7 +27,7 @@ $wgSitename = "Dev wiki instance";
 ## (like /w/index.php/Page_title to /wiki/Page_title) please see:
 ## https://www.mediawiki.org/wiki/Manual:Short_URL
 $wgScriptPath = (getenv('SCRIPT_PATH') != '') ? getenv('SCRIPT_PATH') : "";
-$wgArticlePath = (getenv('ARTICLE_PATH') != '') ? getenv('ARTICLE_PATH') : $wgArticlePath;
+$wgArticlePath = (getenv('ARTICLE_PATH') != '') ? getenv('ARTICLE_PATH') : "/$1";
 
 ## The protocol and server name to use in fully-qualified URLs
 $host = (getenv('HOST') != '') ? getenv('HOST') : 'localhost';


### PR DESCRIPTION
making sure no gcpedia config that's still relevant in mw1.40+ is missed

 * allow for memcached cache type
 * allowed file extensions update
 * wgScriptPath and wgArticlePath, which will also need to work with nginx
 * extra namespace config
 * env variables for wgPasswordSender and wgSMTP