### PR TITLE
enable DeletePagesForGood extensions

### DIFF
--- a/config-gcpedia.php
+++ b/config-gcpedia.php
@@ -72,8 +72,15 @@ $wgDefaultUserOptions["usebetatoolbar-cgd"] = 0;
 $wgDefaultUserOptions["wikieditor-preview"] = 0;
 
 wfLoadExtension( "Cite" );
-$wgGroupPermissions["IMadmin"]   ["delete"] = true;
-$wgGroupPermissions["IMadmin"]   ["undelete"] = true;
+
+wfLoadExtension( 'DeletePagesForGood' );
+$wgGroupPermissions['*']         ['deleteperm'] = false;
+$wgGroupPermissions['user']      ['deleteperm'] = false;
+$wgGroupPermissions['bureaucrat']['deleteperm'] = true;
+$wgGroupPermissions['sysop']     ['deleteperm'] = false;
+$wgGroupPermissions['IMadmin']   ['deleteperm'] = true;
+$wgGroupPermissions['IMadmin']   ['delete'] = true;
+$wgGroupPermissions['IMadmin']   ['undelete'] = true;
 
 wfLoadExtension( "CharInsert" );
 wfLoadExtension( "TreeAndMenu" );

--- a/config.php
+++ b/config.php
@@ -61,8 +61,15 @@ $wgDefaultUserOptions["usebetatoolbar-cgd"] = 0;
 $wgDefaultUserOptions["wikieditor-preview"] = 0;
 
 wfLoadExtension( "Cite" );
-$wgGroupPermissions["IMadmin"]   ["delete"] = true;
-$wgGroupPermissions["IMadmin"]   ["undelete"] = true;
+
+wfLoadExtension( 'DeletePagesForGood' );
+$wgGroupPermissions['*']         ['deleteperm'] = false;
+$wgGroupPermissions['user']      ['deleteperm'] = false;
+$wgGroupPermissions['bureaucrat']['deleteperm'] = true;
+$wgGroupPermissions['sysop']     ['deleteperm'] = false;
+$wgGroupPermissions['IMadmin']   ['deleteperm'] = true;
+$wgGroupPermissions['IMadmin']   ['delete'] = true;
+$wgGroupPermissions['IMadmin']   ['undelete'] = true;
 
 wfLoadExtension( "CharInsert" );
 wfLoadExtension( "TreeAndMenu" );


### PR DESCRIPTION
The fix is in the extension's [REL1_41 branch](https://github.com/wikimedia/mediawiki-extensions-DeletePagesForGood/tree/REL1_41), so should work properly when updating from then on.