### PR TITLE
extract sidebar title text feature into an extension

### DIFF
--- a/config-gcpedia.php
+++ b/config-gcpedia.php
@@ -178,3 +178,5 @@ wfLoadExtension( "RandomImage" );
 wfLoadExtension( "TimedMediaHandler" );
 $wgEnableTranscode = false;
 $wgFFmpegLocation = '/usr/bin/ffmpeg';
+
+wfLoadExtension("SidebarTitleText");

--- a/extensions/SidebarTitleText/SidebarTitleTextHooks.php
+++ b/extensions/SidebarTitleText/SidebarTitleTextHooks.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Allow adding a title text to custom sidebar menu items
+ */
+
+class SidebarTitleTextHooks {
+	/**
+	 * @param Skin $skin
+	 * @param &$bar
+	 * @return bool true
+	 */
+	public static function onSkinBuildSidebar( Skin $skin, &$bar ) {
+        foreach ($bar as $mkey => $menu) {
+            foreach ($menu as $ikey => $menuItem) {
+                if ( strpos($menuItem["text"], "|") ){
+                    $parts = explode("|", $menuItem["text"], 2);
+                    $bar[$mkey][$ikey]["text"] = SidebarTitleTextHooks::menuItemText($skin, $parts[0]);
+                    $bar[$mkey][$ikey]["title"] = SidebarTitleTextHooks::menuItemText($skin, $parts[1]);
+                }
+            }
+        }
+		return;
+	}
+
+    private static function menuItemText( Skin $skin, string $text ){
+        $message = $skin->msg( $text );
+        // parse as an i18n message if it's registered as such
+        if ( $message->exists() ) {
+            return $message->text();
+        }
+
+        return $text;
+    }
+}
+
+

--- a/extensions/SidebarTitleText/extension.json
+++ b/extensions/SidebarTitleText/extension.json
@@ -1,0 +1,23 @@
+{
+	"name": "SidebarTitleText",
+	"version": "1.0",
+	"author": "GCtools",
+	"url": "https://github.com/gctools-outilsgc/gcpedia",
+	"descriptionmsg": "sidebartitletext-desc",
+	"type": "other",
+	"requires": {
+		"MediaWiki": ">= 1.40.0"
+	},
+	"MessagesDirs": {
+		"SidebarTitleText": [
+			"i18n"
+		]
+	},
+	"AutoloadClasses": {
+		"SidebarTitleTextHooks": "SidebarTitleTextHooks.php"
+	},
+	"Hooks": {
+		"SkinBuildSidebar": "SidebarTitleTextHooks::onSkinBuildSidebar"
+	},
+	"manifest_version": 2
+}

--- a/extensions/SidebarTitleText/i18n/en.json
+++ b/extensions/SidebarTitleText/i18n/en.json
@@ -1,0 +1,3 @@
+{
+    "sidebartitletext-desc": ""
+}

--- a/extensions/SidebarTitleText/i18n/fr.json
+++ b/extensions/SidebarTitleText/i18n/fr.json
@@ -1,0 +1,3 @@
+{
+    "sidebartitletext-desc": ""
+}


### PR DESCRIPTION
This is a recreation of the feature in https://github.com/gctools-outilsgc/gcpedia/pull/75 that modified skins.php to allow adding title text for custom sidebar items like the default ones have.

closes #206 