### PR TITLE
ci: Remove invalid node-version variable

### DIFF
--- a/.github/workflows/e2e-tests-reviews.yml
+++ b/.github/workflows/e2e-tests-reviews.yml
@@ -22,11 +22,9 @@ jobs:
     steps:
       - uses: actions/setup-node@v3.5.1
       - uses: actions/checkout@v4
-      # - uses: fregante/setup-git-user@v2
         with:
           repository: gctools-outilsgc/gcpedia
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
-          node-version: 18
           ref: gh-pages
 
       - name: Set up GitHub Actions bot identity


### PR DESCRIPTION
Seems related to the commented out action, which gives warnings currently.
```
Warning: Unexpected input(s) 'node-version', valid inputs are ['repository', 'ref', 'token', 'ssh-key', 'ssh-known-hosts', 'ssh-strict', 'ssh-user', 'persist-credentials', 'path', 'clean', 'filter', 'sparse-checkout', 'sparse-checkout-cone-mode', 'fetch-depth', 'fetch-tags', 'show-progress', 'lfs', 'submodules', 'set-safe-directory', 'github-server-url']
```