### PR TITLE
Update default sidebar set in in GC_Messages extension

### DIFF
--- a/extensions/GC_Messages/GC_Messages.i18n.php
+++ b/extensions/GC_Messages/GC_Messages.i18n.php
@@ -14,16 +14,17 @@ XHTML id it should only appear once and include characters that are legal
 XHTML id names.
 */
 'sidebar' => '
-* navigation
-** mainpage|mainpage-description
-** portal-url|portal
-** currentevents-url|currentevents
-** recentchanges-url|recentchanges
-** randompage-url|randompage
-** helppage|help
+* LANGUAGES
 * SEARCH
-* TOOLBOX
-* LANGUAGES', # do not translate or duplicate this message to other languages
+
+* navigation
+** mainpage|mainpage
+** browsecategoriesURL|Browse categories
+** Special:Random|Random page
+** PDF | {{fullurl:{{FULLPAGENAME}}|action=pdfbook}}&format=single&pdfNumbering=false
+** https://support.gccollab.ca|Help
+
+* ACTIONS', # do not translate or duplicate this message to other languages
 
 # User preference toggles
 'tog-underline'               => 'Link underlining:',


### PR DESCRIPTION
Sets to the current prod gcwiki version and added the new PDF generation link from #252
If necessary may later add separate defaults for gcpedia and gcwiki.