### PR TITLE
remove heading magic word extensions from config-gcpedia.php

### DIFF
--- a/site/config-gcpedia.php
+++ b/site/config-gcpedia.php
@@ -75,8 +75,6 @@ $wgFooterIcons = [
 ////  extensions
 wfLoadExtension("ParserFunctions");
 
-require_once "$IP/extensions/MagicNoNumberedHeadings/MagicNoNumberedHeadings.php";
-require_once "$IP/extensions/MagicNumberedHeadings/MagicNumberedHeadings.php";
 require_once "$IP/extensions/Multilang/multilang.php";
 
 wfLoadExtension("UniversalLanguageSelector");


### PR DESCRIPTION
They no longer work after a recent parser change that removed the flag those toggled, as a result __NONUMBEREDHEADINGS__ behaviour is the only way headings work now.