### PR TITLE
add DismissableSiteNotice extension

### DIFF
--- a/setup_mediawiki.sh
+++ b/setup_mediawiki.sh
@@ -64,6 +64,7 @@ EXTENSIONS=(
     "Widgets"
     "PluggableAuth"
     "OpenIDConnect"
+    "DismissableSiteNotice"
 )
 
 for EXT in "${EXTENSIONS[@]}"; do

--- a/site/config-gcpedia.php
+++ b/site/config-gcpedia.php
@@ -201,3 +201,10 @@ wfLoadExtension("TimedMediaHandler");
 $wgEnabledTranscodeSet = [];
 $wgFFmpegLocation = '/usr/bin/ffmpeg';
 $wgEnableTranscode = false;
+
+
+wfLoadExtension("DismissableSiteNotice");
+// This is the value of the cookie used to keep track of the site notice being dismissed
+// increment it when a new one goes up
+$wgMajorSiteNoticeID = 0.0;
+$wgDismissableSiteNoticeForAnons = true;

--- a/site/config-gcwiki.php
+++ b/site/config-gcwiki.php
@@ -187,3 +187,9 @@ if (empty($missingVars)) {
 
 require_once "$IP/extensions/googleAnalytics/googleAnalytics.php";
 $wgGoogleAnalyticsAccount = $GAaccount;
+
+wfLoadExtension("DismissableSiteNotice");
+// This is the value of the cookie used to keep track of the site notice being dismissed
+// increment it when a new one goes up
+$wgMajorSiteNoticeID = 0.0;
+$wgDismissableSiteNoticeForAnons = false;


### PR DESCRIPTION
Try DismissableSiteNotice extension as an alternative to making the sitenotice a collapsible section.
An option to address #273 by working around it instead, would also be less work to maintain.
closes #273 