### PR TITLE
Make the synced azdevops repo a proper mirror, and fix gh-pages branch braking the sync

### DIFF
--- a/azure-pipelines-sync.yaml
+++ b/azure-pipelines-sync.yaml
@@ -21,7 +21,7 @@ jobs:
         cd Sync_directory
         git remote add --mirror=fetch upstream https://github.com/gctools-outilsgc/$REPO_NAME
         git fetch upstream --tags
-        git push origin --all
+        git push origin --all --mirror
       env:
         REPO_NAME: "gcpedia"
       displayName: 'Sync repo'


### PR DESCRIPTION
1. Prune deleted branches in the azdevops mirror
2. Force updates so gh-pages branch doesn't keep breaking the sync.