### PR TITLE
Change cache settings to only allow options that don't break auth in multi-instance environments

### DIFF
--- a/site/LocalSettings.php
+++ b/site/LocalSettings.php
@@ -73,7 +73,7 @@ $wgSharedTables[] = "actor";
 
 ## Shared memory settings
 $wgMainCacheType = (getenv('CACHE_TYPE') == 'CACHE_MEMCACHED') ? CACHE_MEMCACHED : CACHE_NONE;
-$wgMemCachedServers = (getenv('MEMCACHED_HOST') != '') ? getenv('MEMCACHED_HOST') : $wgMemCachedServers;
+$wgMemCachedServers = (getenv('MEMCACHED_HOST') != '') ? [getenv('MEMCACHED_HOST')] : $wgMemCachedServers;
 
 ## To enable image uploads, make sure the 'images' directory
 ## is writable, then set this to true:

--- a/site/LocalSettings.php
+++ b/site/LocalSettings.php
@@ -72,7 +72,7 @@ $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 $wgSharedTables[] = "actor";
 
 ## Shared memory settings
-$wgMainCacheType = (getenv('CACHE_TYPE') == 'CACHE_MEMCACHED') ? CACHE_MEMCACHED : CACHE_NONE;
+$wgMainCacheType = (getenv('CACHE_TYPE') == 'CACHE_MEMCACHED' && getenv('MEMCACHED_HOST') != '') ? CACHE_MEMCACHED : CACHE_NONE;
 $wgMemCachedServers = (getenv('MEMCACHED_HOST') != '') ? [getenv('MEMCACHED_HOST')] : $wgMemCachedServers;
 
 ## To enable image uploads, make sure the 'images' directory
@@ -141,6 +141,10 @@ if (getenv('WIKI_DEBUG') === 'true') {
 	$wgShowExceptionDetails = true;
 	$wgDebugLogFile = '/tmp/wikiDebug.log';
 	$wgSitename = "Dev wiki instance - DEBUG mode";
+
+	error_reporting( -1 );
+	ini_set( 'display_errors', 1 );
+	ini_set( 'display_startup_errors', 1 );
 }
 
 if (getenv('SITE') == 'gcpedia') {

--- a/site/LocalSettings.php
+++ b/site/LocalSettings.php
@@ -72,7 +72,8 @@ $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 $wgSharedTables[] = "actor";
 
 ## Shared memory settings
-$wgMainCacheType = (getenv('CACHE_TYPE') == 'CACHE_MEMCACHED') ? CACHE_MEMCACHED : CACHE_ACCEL;
+$wgMainCacheType = (getenv('CACHE_TYPE') == 'CACHE_MEMCACHED') ? CACHE_MEMCACHED : CACHE_NONE;
+$wgMemCachedServers = (getenv('MEMCACHED_HOST') != '') ? getenv('MEMCACHED_HOST') : $wgMemCachedServers;
 
 ## To enable image uploads, make sure the 'images' directory
 ## is writable, then set this to true:
@@ -138,6 +139,7 @@ $GAaccount = (getenv('GAACCOUNT') != '') ? getenv('GAACCOUNT') : 'UA-xxxxxxx-x';
 
 if (getenv('WIKI_DEBUG') === 'true') {
 	$wgShowExceptionDetails = true;
+	$wgDebugLogFile = '/tmp/wikiDebug.log';
 	$wgSitename = "Dev wiki instance - DEBUG mode";
 }
 


### PR DESCRIPTION
Local caches for sessions cause issues for auth. An alternative can be to explicitly define $wgSessionCacheType to  CACHE_DB or a common memcached instance while allowing local caches for other purposes.

fixes #303 