### PR TITLE
Attempts at making the skin tweaks not jump out at you after page load, or at least make it a bit more natural

### DIFF
--- a/extensions/SkinTweaksGCwiki/SkinTweaksGCwikiHooks.php
+++ b/extensions/SkinTweaksGCwiki/SkinTweaksGCwikiHooks.php
@@ -35,6 +35,7 @@ class SkinTweaksGCwikiHooks {
 
 
     public static function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
+        $out->addModuleStyles( [ 'ext.skintweaksgcwiki.css' ] );
         $out->addModules( [ 'ext.skintweaksgcwiki' ] );
         return;
     }

--- a/extensions/SkinTweaksGCwiki/extension.json
+++ b/extensions/SkinTweaksGCwiki/extension.json
@@ -14,8 +14,11 @@
 		]
 	},
 	"ResourceModules": {
+		"ext.skintweaksgcwiki.css": {
+			"styles": "css/skintweaksgcwiki.css"
+		},
 		"ext.skintweaksgcwiki": {
-			"styles": "css/skintweaksgcwiki.css",
+			"styles": "css/skintweaksgcwiki-loaded.css",
 			"scripts": "js/skintweaksgcwiki.js"
 		}
 	},

--- a/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki-loaded.css
+++ b/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki-loaded.css
@@ -1,3 +1,6 @@
 div#mw-page-base {
 	height: 5em;
 }
+.vector-header-container {
+        padding-top: 0;
+}

--- a/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki-loaded.css
+++ b/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki-loaded.css
@@ -1,0 +1,3 @@
+div#mw-page-base {
+	height: 5em;
+}

--- a/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki.css
+++ b/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki.css
@@ -2,6 +2,10 @@
 div#mw-head {
 	top: 35px;
 }
+div#mw-page-base {
+	height: 7.2em;
+}
+
 
 #ca-favorite a:focus,
 #ca-unfavorite a:focus,

--- a/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki.css
+++ b/extensions/SkinTweaksGCwiki/resources/css/skintweaksgcwiki.css
@@ -5,7 +5,9 @@ div#mw-head {
 div#mw-page-base {
 	height: 7.2em;
 }
-
+.vector-header-container {
+    padding-top: 2.2em;
+}
 
 #ca-favorite a:focus,
 #ca-unfavorite a:focus,


### PR DESCRIPTION
This works in 2 steps, taking the delay between css-only modules and css+js modules into account:
1. load all css + push down the page by the same amount the top bar will add
2. revert the extra height on #mw-page-base and load the js the inserts the top bar in that space
The top bar still isn't there on load but this way other page elements are in the right position from the start and stay there.

This will also now work for the new vector after the update to 1.43